### PR TITLE
Development

### DIFF
--- a/TestingUserScript.py
+++ b/TestingUserScript.py
@@ -1,4 +1,3 @@
-  
 """
 Unit testing, of a sort, all the created methods/classes.
 """
@@ -14,6 +13,7 @@ host = '10.0.50.50'
 username = 'apiscript'
 password = 'Admin123'
 autodeploy = False
+
 
 # ### These functions are the individual tests you can run to ensure functionality. ### #
 
@@ -450,14 +450,15 @@ def test__interface_group():
 
     obj1 = InterfaceGroup(fmc=fmc1, name="_ig_outside_all")
     obj1.get()
-    obj1.p_interface(device_name="FTDv03.ccie.lab", action="add", names=["GigabitEthernet0/0","GigabitEthernet0/1","GigabitEthernet0/2"])
+    obj1.p_interface(device_name="FTDv03.ccie.lab", action="add",
+                     names=["GigabitEthernet0/0", "GigabitEthernet0/1", "GigabitEthernet0/2"])
     print('InterfaceGroup PUT-->')
     pp.pprint(obj1.format_data())
     print('\n')
     obj1.put()
     time.sleep(1)
     del obj1
-    
+
     obj1 = InterfaceGroup(fmc=fmc1, name="_ig_outside_all")
     obj1.get()
     obj1.p_interface(device_name="FTDv03.ccie.lab", action="remove", names=["GigabitEthernet0/1"])
@@ -467,7 +468,7 @@ def test__interface_group():
     obj1.put()
     time.sleep(1)
     del obj1
-    
+
     obj1 = InterfaceGroup(fmc=fmc1, name="_ig_outside_all")
     obj1.get()
     obj1.p_interface(action="clear-all")
@@ -504,7 +505,7 @@ def test__slamonitor():
     obj1.noOfPackets = 1
     obj1.dataSize = 28
     obj1.tos = 1
-    obj1.interfaces(names=["SZ-OUTSIDE1","SZ-OUTSIDE2"])
+    obj1.interfaces(names=["SZ-OUTSIDE1", "SZ-OUTSIDE2"])
     obj1.post()
     print('SLAMonitor Post -->')
     pp.pprint(obj1.format_data())
@@ -539,6 +540,7 @@ def test__device():
     print('\n')
     acp1.delete()
     logging.info('# Test Device done.\n')
+
 
 def test__device_with_task():
     logging.info('# Test Device1 with Task.  This requires having an actual device with the "configure manager add" '
@@ -584,7 +586,7 @@ def test__device_with_task():
     response = obj2.post()
     wait_for_task(response["metadata"]["task"], 30)
 
-    #Wait some additional time to complete device registration before deletion
+    # Wait some additional time to complete device registration before deletion
     time.sleep(180)
     obj1 = Device(fmc=fmc1)
     obj2 = Device(fmc=fmc1)
@@ -596,6 +598,7 @@ def test__device_with_task():
     obj2.delete()
     time.sleep(30)
     acp1.delete()
+
 
 def test__phys_interfaces():
     logging.info('# Test PhysicalInterface.  get, put PhysicalInterface Objects. Requires registered device')
@@ -659,7 +662,7 @@ def test__phys_interfaces():
     sz2.delete()
 
 
-def test__device_ha_pair():    
+def test__device_ha_pair():
     logging.info('# Test DeviceHAPairs. After an HA Pair is created, all API calls to "devicerecords" objects should '
                  'be directed at the currently active device not the ha pair')
     failover1 = PhysicalInterface(fmc=fmc1)
@@ -670,44 +673,44 @@ def test__device_ha_pair():
     obj1.primary(name="PrimaryName")
     obj1.secondary(name="SecondaryName")
     obj1.name = "HaName"
-    #failover interface subnetMask must be in x.x.x.x format"
+    # failover interface subnetMask must be in x.x.x.x format"
     obj1.ftdHABootstrap = {
         "isEncryptionEnabled": "true",
         "encKeyGenerationScheme": "CUSTOM",
         "sharedKey": "cisco123",
         "useSameLinkForFailovers": False,
         "lanFailover": {
-          "useIPv6Address": False,
-          "subnetMask": "255.255.255.252",
-          "interfaceObject": {
-            "type": "PhysicalInterface",
-            "name": failover1.name,
-            "id": failover1.id
-          },
-          "standbyIP": "192.168.1.2",
-          "logicalName": "HA-FAILOVER",
-          "activeIP": "192.168.1.1"
+            "useIPv6Address": False,
+            "subnetMask": "255.255.255.252",
+            "interfaceObject": {
+                "type": "PhysicalInterface",
+                "name": failover1.name,
+                "id": failover1.id
+            },
+            "standbyIP": "192.168.1.2",
+            "logicalName": "HA-FAILOVER",
+            "activeIP": "192.168.1.1"
         },
         "statefulFailover": {
-          "useIPv6Address": False,
-          "subnetMask": "255.255.255.252",
-          "interfaceObject": {
-            "type": "PhysicalInterface",
-            "name": stateful1.name,
-            "id": stateful1.id
-          },
-          "standbyIP": "192.168.1.6",
-          "logicalName": "HA-STATEFUL",
-          "activeIP": "192.168.1.5"}}
-    #response = ha_pair.post()
-    #wait_for_task(response["metadata"]["task"], 30)
+            "useIPv6Address": False,
+            "subnetMask": "255.255.255.252",
+            "interfaceObject": {
+                "type": "PhysicalInterface",
+                "name": stateful1.name,
+                "id": stateful1.id
+            },
+            "standbyIP": "192.168.1.6",
+            "logicalName": "HA-STATEFUL",
+            "activeIP": "192.168.1.5"}}
+    # response = ha_pair.post()
+    # wait_for_task(response["metadata"]["task"], 30)
     print('Device HA-->')
     pp.pprint(obj1.format_data())
     print('\n')
     obj1.post()
     time.sleep(300)
     del obj1
-    
+
     obj1 = DeviceHAPairs(fmc=fmc1, name="HaName")
     obj1.switch_ha()
     print('Device HA Switch-->')
@@ -726,21 +729,21 @@ def test__device_ha_pair():
     response = obj1.put()
     print(response)
 
-    #time.sleep(300)
-    #del obj1
-    #obj1 = DeviceHAPairs(fmc=fmc1)
-    #obj1.get(name="FTDv-HA2")
-    #Deleting the HAPair object will delete the HA configuration AND remove the devices from the FPMC
-    #response = obj1.delete()
+    # time.sleep(300)
+    # del obj1
+    # obj1 = DeviceHAPairs(fmc=fmc1)
+    # obj1.get(name="FTDv-HA2")
+    # Deleting the HAPair object will delete the HA configuration AND remove the devices from the FPMC
+    # response = obj1.delete()
 
 
 def test__device_ha_monitored_interfaces():
     logging.info('# Test DeviceHAMonitoredInterfaces. get, put DeviceHAMonitoredInterfaces Objects')
     obj1 = DeviceHAMonitoredInterfaces(fmc=fmc1, ha_name="HaName")
-    #Interface logical name (ifname)
+    # Interface logical name (ifname)
     obj1.get(name="OUTSIDE1")
     obj1.monitorForFailures = True
-    obj1.ipv4(ipv4addr="10.254.0.4",ipv4mask=29,ipv4standbyaddr="10.254.0.3")
+    obj1.ipv4(ipv4addr="10.254.0.4", ipv4mask=29, ipv4standbyaddr="10.254.0.3")
     print('DeviceHAMonitoredInterfaces PUT-->')
     pp.pprint(obj1.format_data())
     print('\n')
@@ -748,7 +751,6 @@ def test__device_ha_monitored_interfaces():
 
 
 def test__device_ha_failover_mac():
-    
     logging.info('# Test DeviceHAFailoverMAC. get, post, put, delete DeviceHAFailoverMAC Objects')
     obj1 = DeviceHAFailoverMAC(fmc=fmc1, ha_name="HaName")
     obj1.p_interface(name="GigabitEthernet0/0", device_name="device-name")
@@ -758,7 +760,7 @@ def test__device_ha_failover_mac():
     pp.pprint(obj1.format_data())
     print('\n')
     obj1.post()
-    del obj1    
+    del obj1
 
     obj1 = DeviceHAFailoverMAC(fmc=fmc1)
     obj1.edit(name="GigabitEthernet0/0", ha_name="HaName")
@@ -935,6 +937,7 @@ def test__port_object_group():
     obj12.delete()
     logging.info('# Testing PortObjectGroup class done.\n')
 
+
 def wait_for_task(task, wait_time=10):
     try:
         status = TaskStatuses(
@@ -957,7 +960,9 @@ def wait_for_task(task, wait_time=10):
             time.sleep(wait_time)
             current_status = status.get()
         print("Task: %s %s %s %s" % (current_status["taskType"], current_status["status"], current_status["id"]))
-    except Exception as e: print(type(e),e)
+    except Exception as e:
+        print(type(e), e)
+
 
 # ### Main Program ### #
 
@@ -992,20 +997,20 @@ with FMC(host=host, username=username, password=password, autodeploy=autodeploy)
     test__protocol_port()
     test__slamonitor()
     test__security_zone()
-    #test__interface_group()
+    # test__interface_group()
     test__device()
 
-    #test__phys_interfaces()
-    #test__device_ha_pair()
-    #test__device_ha_monitored_interfaces()
-    #test__device_ha_failover_mac()
+    # test__phys_interfaces()
+    # test__device_ha_pair()
+    # test__device_ha_monitored_interfaces()
+    # test__device_ha_failover_mac()
     test__intrusion_policy()
     test__access_control_policy()
     test__acp_rule()
     test__audit()
     test__port_object_group()
 
-    #test__device_with_task()
+    # test__device_with_task()
     test__intrusion_policy()
     test__access_control_policy()
     test__acp_rule()

--- a/TestingUserScript.py
+++ b/TestingUserScript.py
@@ -2,16 +2,18 @@
 Unit testing, of a sort, all the created methods/classes.
 """
 
-from fmcapi import *
+from fmcapi.fmc import *
+from fmcapi.api_objects import *
+from fmcapi.helper_functions import *
 import logging
 import time
 import pprint
 
 # ### Set these variables to match your environment. ### #
 
-host = '10.0.50.50'
+host = 'fmclab.tor.afilias-int.info'
 username = 'apiscript'
-password = 'Admin123'
+password = 'XXXXXXXX'
 autodeploy = False
 
 

--- a/fmcapi/__init__.py
+++ b/fmcapi/__init__.py
@@ -2,19 +2,19 @@
 The fmcapi __init__.py file is called whenever someone imports the package into their program.
 """
 
-from .fmc import *
-from .api_objects import *
-from .helper_functions import *
+#from .fmc import *
+#from .api_objects import *
+#from .helper_functions import *
 import logging
 
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+#logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # Its always good to set up a log file.
 logging_format = '%(asctime)s - %(levelname)s:%(filename)s:%(lineno)s - %(message)s'
 logging_dateformat = '%Y/%m/%d-%H:%M:%S'
 # Logging level options are logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL
 logging_level = logging.INFO
-# logging_level = logging.DEBUG
+#ogging_level = logging.DEBUG
 logging_filename = 'output.log'
 logging.basicConfig(format=logging_format,
                     datefmt=logging_dateformat,

--- a/fmcapi/__init__.py
+++ b/fmcapi/__init__.py
@@ -2,19 +2,19 @@
 The fmcapi __init__.py file is called whenever someone imports the package into their program.
 """
 
-#from .fmc import *
-#from .api_objects import *
-#from .helper_functions import *
+# from .fmc import *
+# from .api_objects import *
+# from .helper_functions import *
 import logging
 
-#logging.getLogger(__name__).addHandler(logging.NullHandler())
+# logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # Its always good to set up a log file.
 logging_format = '%(asctime)s - %(levelname)s:%(filename)s:%(lineno)s - %(message)s'
 logging_dateformat = '%Y/%m/%d-%H:%M:%S'
 # Logging level options are logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL
 logging_level = logging.INFO
-#ogging_level = logging.DEBUG
+# ogging_level = logging.DEBUG
 logging_filename = 'output.log'
 logging.basicConfig(format=logging_format,
                     datefmt=logging_dateformat,
@@ -26,13 +26,14 @@ logging.debug("In the fmcapi __init__.py file.")
 
 
 def __authorship__():
-        """In the FMC __authorship__() class method:
+    """In the FMC __authorship__() class method:
 ***********************************************************************************************************************
 This python module was created by Dax Mickelson along with LOTs of help from Ryan Malloy and Neil Patel.
 Feel free to send me comments/suggestions/improvements.  Either by email: dmickels@cisco.com or more importantly
 via a Pull request from the github repository: https://github.com/daxm/fmcapi.
 ***********************************************************************************************************************
         """
-        logging.debug(__authorship__.__doc__)
+    logging.debug(__authorship__.__doc__)
+
 
 __authorship__()

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -3145,7 +3145,7 @@ class ManualNatRules(APIClassTemplate):
         ftd_nat.get(name=name)
         if 'id' in ftd_nat.__dict__:
             self.nat_id = ftd_nat.id
-            self.URL = '{}{}/{}/autonatrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)
+            self.URL = '{}{}/{}/manualnatrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)
             self.nat_added_to_url = True
         else:
             logging.warning('FTD NAT Policy {} not found.  Cannot set up ManualNatRule for '
@@ -3383,7 +3383,6 @@ class NatRules(APIClassTemplate):
         ftd_nat.get(name=name)
         if 'id' in ftd_nat.__dict__:
             self.nat_id = ftd_nat.id
-            self.URL = '{}{}/{}/autonatrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)
             self.URL = '{}{}/{}/natrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)
             self.nat_added_to_url = True
         else:

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -3382,8 +3382,10 @@ class NatRules(APIClassTemplate):
         ftd_nat = FTDNatPolicy(fmc=self.fmc)
         ftd_nat.get(name=name)
         if 'id' in ftd_nat.__dict__:
+            print(ftd_nat.__dict__)
             self.nat_id = ftd_nat.id
             self.URL = '{}{}/{}/autonatrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)
+            self.URL = '{}{}/{}/natrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)
             self.nat_added_to_url = True
         else:
             logging.warning('FTD NAT Policy {} not found.  Cannot set up NatRules for '

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -3382,7 +3382,6 @@ class NatRules(APIClassTemplate):
         ftd_nat = FTDNatPolicy(fmc=self.fmc)
         ftd_nat.get(name=name)
         if 'id' in ftd_nat.__dict__:
-            print(ftd_nat.__dict__)
             self.nat_id = ftd_nat.id
             self.URL = '{}{}/{}/autonatrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)
             self.URL = '{}{}/{}/natrules'.format(self.fmc.configuration_url, self.PREFIX_URL, self.nat_id)

--- a/fmcapi/fmc.py
+++ b/fmcapi/fmc.py
@@ -34,7 +34,7 @@ via its API.  Each method has its own DOCSTRING (like this triple quoted text he
     API_CONFIG_VERSION = 'api/fmc_config/v1'
     API_PLATFORM_VERSION = 'api/fmc_platform/v1'
     VERIFY_CERT = False
-    MAX_PAGING_REQUESTS = 200
+    MAX_PAGING_REQUESTS = 2000
 
     def __init__(self, host='192.168.45.45', username='admin', password='Admin123', domain=None, autodeploy=True):
         """

--- a/scratch.py
+++ b/scratch.py
@@ -1,0 +1,86 @@
+from fmcapi.fmc import *
+from fmcapi.api_objects import *
+from fmcapi.helper_functions import *
+import time
+from pprint import pprint as pp
+import json
+import sys
+# ### Set these variables to match your environment. ### #
+
+host = 'fmclab.tor.afilias-int.info'
+username = 'apiadmin'
+password = 'LetsTalkAPI'
+autodeploy = False
+
+
+class PyJSON(object):
+    def __init__(self, d):
+        if type(d) is str:
+            d = json.loads(d)
+        self.from_dict(d)
+
+    def from_dict(self, d):
+        self.__dict__ = {}
+        for key, value in d.items():
+            if type(value) is dict:
+                value = PyJSON(value)
+            self.__dict__[key] = value
+
+    def to_dict(self):
+        d = {}
+        for key, value in self.__dict__.items():
+            if type(value) is PyJSON:
+                value = value.to_dict()
+            d[key] = value
+        return d
+
+    def __repr__(self):
+        return str(self.to_dict())
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+
+def get_nat(fmc, policy_name):
+    '''
+    Seems to return only AutoNat Rules
+    '''
+    result = NatRules(fmc)
+    for policy in policy_name:
+        print('Printing NAT rules for policy: {}'.format(policy.upper()))
+        logging.debug('Printing NAT rules for policy: {}'.format(policy))
+        result.nat_policy(policy)
+        nat_rules = result.get()
+        #pp.pprint(nat_rules)
+        #[print(PyJSON(element).destinationInterface.name, PyJSON(element).natType, PyJSON(element).originalNetwork.name) for element in nat_rules['items']]
+
+        return nat_rules
+
+
+def get_nat_policy_names(fmc):
+    policy = FTDNatPolicy(fmc)
+    result = [PyJSON(policy_nat_dict).name for policy_nat_dict in policy.get()['items']]
+    #print('Function get_nat_policy_names returns: {}'. format(result))
+    return result
+
+
+with FMC(host=host, username=username, password=password, autodeploy=autodeploy) as fmc1:
+
+    nat_policy_names = get_nat_policy_names(fmc1)
+    k = get_nat(fmc1, nat_policy_names)
+
+if 'items' in k:
+    for e in (map(lambda x : PyJSON(x),k['items'])):
+        if e.metadata.section == 'AUTO':
+            print(e.sourceInterface.name, e.originalNetwork.name, e.destinationInterface.name, e.translatedNetwork.name)
+        if e.metadata.section == 'BEFORE_AUTO':
+            print(e.sourceInterface.name, e.destinationInterface.name, e.originalSource.name, e.translatedSource.name)
+
+
+
+
+
+


### PR DESCRIPTION
Mostly fixing url in nat_policy method of  classes ManualNatRules and NatRules in api_objects.py, which were pointing to the wrong url (all point to /path/to/version/autonatrules, as opposed to the correct endpoint) as a result of this the get() methods on each retrieved only the "autonat rules" on all Nat related classes.

Feel free to not merge and fix in master yourself. I wanted to merely point to these two issues.
I have tested this and it seems to work however, I haven't spent enough time with the code to fully go through it (so I may be terribly mistaken :-) )