### PR TITLE
Remove file logger enabled by default

### DIFF
--- a/fmcapi/__init__.py
+++ b/fmcapi/__init__.py
@@ -6,22 +6,6 @@ The fmcapi __init__.py file is called whenever someone imports the package into 
 # from .api_objects import *
 # from .helper_functions import *
 import logging
-
-# logging.getLogger(__name__).addHandler(logging.NullHandler())
-
-# Its always good to set up a log file.
-logging_format = '%(asctime)s - %(levelname)s:%(filename)s:%(lineno)s - %(message)s'
-logging_dateformat = '%Y/%m/%d-%H:%M:%S'
-# Logging level options are logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL
-logging_level = logging.INFO
-# ogging_level = logging.DEBUG
-logging_filename = 'output.log'
-logging.basicConfig(format=logging_format,
-                    datefmt=logging_dateformat,
-                    filename=logging_filename,
-                    filemode='w',
-                    level=logging_level)
-
 logging.debug("In the fmcapi __init__.py file.")
 
 

--- a/fmcapi/fmc.py
+++ b/fmcapi/fmc.py
@@ -36,14 +36,28 @@ via its API.  Each method has its own DOCSTRING (like this triple quoted text he
     VERIFY_CERT = False
     MAX_PAGING_REQUESTS = 2000
 
-    def __init__(self, host='192.168.45.45', username='admin', password='Admin123', domain=None, autodeploy=True):
+    def __init__(self, host='192.168.45.45', username='admin', password='Admin123', domain=None, autodeploy=True,
+                 file_logging=None, debug=False):
         """
         Instantiate some variables prior to calling the __enter__() method.
         :param host:
         :param username:
         :param password:
         :param autodeploy:
+        :param file_logging (str): The filename (and optional path) of the output file if a file logger is required, None if no
+                                   file logger is required
+        :param debug (bool): True to enable debug logging, default is False
         """
+
+        root_logger = logging.getLogger('')
+        root_logger.setLevel(logging.DEBUG if debug else logging.INFO)
+
+        if file_logging:
+            formatter = logging.Formatter('%(asctime)s - %(levelname)s:%(filename)s:%(lineno)s - %(message)s', '%Y/%m/%d-%H:%M:%S')
+            file_logger = logging.FileHandler(file_logging)
+            file_logger.setFormatter(formatter)
+            root_logger.addHandler(file_logger)
+
         logging.debug("In the FMC __init__() class method.")
 
         self.host = host


### PR DESCRIPTION
File logging shouldn't be enabled by default in this package. Every time this package is loaded an output file is created so you end up with output files sprinkled all over the place. Anyone can setup their own default logger if they specifically need one for their application prior to calling FMC:

```
file = logging.FileHandler(filename="output.log")
file.setLevel(level=logging.DEBUG)
logger = logging.getLogger()
logger.addHandler(file)

with FMC(...
```
