### PR TITLE
Feature/literal support in acp rule

### DIFF
--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4938,7 +4938,7 @@ class ACPRule(APIClassTemplate):
                         logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
                 else:
                     # None of literals or objects are present in sourceNetworks,
-                    # so initialize it to literals and update the provided literal
+                    # so initialize it with literals and update the provided literal
                     self.sourceNetworks = {'literals': [literal]}
                     logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
             else:

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4916,13 +4916,17 @@ class ACPRule(APIClassTemplate):
             if literal != dict():
                 # some value of literal is present
                 if 'sourceNetworks' in self.__dict__:
-                    duplicate = False
-                    for litr in self.sourceNetworks['literals']:
-                        if litr['value'] == literal['value']:
-                            duplicate = True
-                            break
-                    if not duplicate:
-                        self.sourceNetworks['literals'].append(literal)
+                    if 'literals' in self.__dict__['sourceNetworks']:
+                        duplicate = False
+                        for litr in self.sourceNetworks['literals']:
+                            if litr['value'] == literal['value']:
+                                duplicate = True
+                                break
+                        if not duplicate:
+                            self.sourceNetworks['literals'].append(literal)
+                            logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
+                    else:
+                        self.sourceNetworks.update({'literals':[literal]})
                         logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
                 else:
                     self.sourceNetworks = {'literals': [literal]}

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4550,8 +4550,8 @@ class ACPRule(APIClassTemplate):
             json_data['sourceNetworks'] = {'objects': self.sourceNetworks['objects']}
             json_data['sourceNetworks']['literals'] = [{'type': k, 'value': v} for k, v in enumerate(self.sourceNetworks['literals'])]
         if 'destinationNetworks' in self.__dict__:
-            json_data['sourceNetworks'] = {'objects': self.destinationNetworks['objects']}
-            json_data['sourceNetworks']['literals'] = [{'type': k, 'value': v} for k, v in enumerate(self.destintationNetworks['literals'])]
+            json_data['destinationNetworks'] = {'objects': self.destinationNetworks['objects']}
+            json_data['destinationNetworks']['literals'] = [{'type': k, 'value': v} for k, v in enumerate(self.destinationNetworks['literals'])]
         if 'sourcePorts' in self.__dict__:
             json_data['sourcePorts'] = self.sourcePorts
         if 'destinationPorts' in self.__dict__:

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4990,7 +4990,6 @@ class ACPRule(APIClassTemplate):
                         # so initialize it with objects and update the provided object
                         self.sourceNetworks = {'objects': [new_net]}
                         logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(name))
-
         elif action == 'remove':
             if 'sourceNetworks' in self.__dict__:
                 if name != '':

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -5102,7 +5102,11 @@ class ACPRule(APIClassTemplate):
                                 self.destinationNetworks['objects'].append(new_net)
                                 logging.info('Adding "{}" to destinationNetworks for this ACPRule.'.format(name))
                         else:
-                            self.destinationNetworks = {'objects': [new_net]}
+                            # this means no objects were present in destinationNetworks,
+                            # and destinationNetworks contains literals only
+                            self.destinationNetworks.update({'objects': [new_net]})
+                            # So update the destinationNetworks dict which contained 'literals' key initially
+                            # to have a 'objects' key as well
                             logging.info('Adding "{}" to destinationNetworks for this ACPRule.'.format(name))
                     else:
                         # None of literals or objects are present in destinationNetworks,

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4918,7 +4918,7 @@ class ACPRule(APIClassTemplate):
         """
         # using dict() as default value is dangerous here, any thoughts/workarounds on this?
         logging.debug("In source_network() for ACPRule class.")
-        if literal != '' and name != '':
+        if literal != dict() and name != '':
             raise ValueError('Only one of literals or name (object name) should be set while creating a source network')
 
         if action == 'add':

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4998,8 +4998,13 @@ class ACPRule(APIClassTemplate):
                     for obj in self.sourceNetworks['objects']:
                         if obj['name'] != name:
                             objects.append(obj)
-                    self.sourceNetworks['objects'] = objects
-                    logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(name))
+                    if len(objects) == 0:
+                        del self.sourceNetworks
+                        logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
+                        logging.info('All Source Networks removed from this ACPRule object.')
+                    else:
+                        self.sourceNetworks['objects'] = objects
+                        logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(name))
                 else:
                     # a literal value has been provided to be removed
                     literals = []

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -5001,7 +5001,7 @@ class ACPRule(APIClassTemplate):
                     if len(objects) == 0:
                         # it was the last object which was deleted now
                         del self.sourceNetworks
-                        logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(name))
+                        logging.info('Removed "{}" from sourceNetworks for this ACPRule'.format(name))
                         logging.info('All Source Networks removed from this ACPRule object.')
                     else:
                         self.sourceNetworks['objects'] = objects

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4548,10 +4548,10 @@ class ACPRule(APIClassTemplate):
             json_data['vlanTags'] = self.vlanTags
         if 'sourceNetworks' in self.__dict__:
             json_data['sourceNetworks'] = {'objects': self.sourceNetworks['objects']}
-            json_data['sourceNetworks']['literals'] = [{'name': k, 'value': v} for k, v in enumerate(self.sourceNetworks['literals'])]
+            json_data['sourceNetworks']['literals'] = [{'type': k, 'value': v} for k, v in enumerate(self.sourceNetworks['literals'])]
         if 'destinationNetworks' in self.__dict__:
             json_data['sourceNetworks'] = {'objects': self.destinationNetworks['objects']}
-            json_data['sourceNetworks']['literals'] = [{'name': k, 'value': v} for k, v in enumerate(self.destintationNetworks['literals'])]
+            json_data['sourceNetworks']['literals'] = [{'type': k, 'value': v} for k, v in enumerate(self.destintationNetworks['literals'])]
         if 'sourcePorts' in self.__dict__:
             json_data['sourcePorts'] = self.sourcePorts
         if 'destinationPorts' in self.__dict__:
@@ -4629,7 +4629,7 @@ class ACPRule(APIClassTemplate):
 
             if kwargs['sourceNetworks'].get('literals'):
                 for literal in kwargs['sourceNetworks']['literals']:
-                    self.sourceNetworks['literals'][literal['name']] = literal['value']
+                    self.sourceNetworks['literals'][literal['value']] = literal['type']
 
         if 'destinationNetworks' in kwargs:
             self.destinationNetworks = {'objects': [], 'literals': {}}
@@ -4639,7 +4639,7 @@ class ACPRule(APIClassTemplate):
 
             if kwargs['destinationNetworks'].get('literals'):
                 for literal in kwargs['destinationNetworks']['literals']:
-                    self.sourceNetworks['literals'][literal['name']] = literal['value']
+                    self.destinationNetworks['literals'][literal['value']] = literal['type']
 
         if 'urls' in kwargs:
             self.urls = kwargs['urls']

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4908,11 +4908,12 @@ class ACPRule(APIClassTemplate):
 
     def source_network(self, action, name='', literal=dict()):
         """
-        Adds Either objects with name
+        Adds Either object having name=name or literal with {value:<>, type:<>} to the sourceNetworks
+        field of acprule object
         Args:
-            action:
-            name:
-            literal:
+            action: the action to be done
+            name: name of the object in question
+            literal: the literal in question
         Returns:
             None
         """

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -5001,7 +5001,7 @@ class ACPRule(APIClassTemplate):
                     if len(objects) == 0:
                         # it was the last object which was deleted now
                         del self.sourceNetworks
-                        logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
+                        logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(name))
                         logging.info('All Source Networks removed from this ACPRule object.')
                     else:
                         self.sourceNetworks['objects'] = objects

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -5006,8 +5006,13 @@ class ACPRule(APIClassTemplate):
                     for litr in self.sourceNetworks['literals']:
                         if litr['value'] != literal['value']:
                             literals.append(litr)
-                    self.sourceNetworks['literals'] = literals
-                    logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
+                    if len(literals) == 0:
+                        del self.sourceNetworks
+                        logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
+                        logging.info('All Source Networks removed from this ACPRule object.')
+                    else:
+                        self.sourceNetworks['literals'] = literals
+                        logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
             else:
                 logging.info("sourceNetworks doesn't exist for this ACPRule.  Nothing to remove.")
         elif action == 'clear':

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4907,6 +4907,15 @@ class ACPRule(APIClassTemplate):
                 logging.info('All Destination Ports removed from this ACPRule object.')
 
     def source_network(self, action, name='', literal=dict()):
+        """
+        Adds Either objects with name
+        Args:
+            action:
+            name:
+            literal:
+        Returns:
+            None
+        """
         # using dict() as default value is dangerous here, any thoughts/workarounds on this?
         logging.debug("In source_network() for ACPRule class.")
         if literal != '' and name != '':
@@ -4984,12 +4993,22 @@ class ACPRule(APIClassTemplate):
 
         elif action == 'remove':
             if 'sourceNetworks' in self.__dict__:
-                objects = []
-                for obj in self.sourceNetworks['objects']:
-                    if obj['name'] != name:
-                        objects.append(obj)
-                self.sourceNetworks['objects'] = objects
-                logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(name))
+                if name != '':
+                    # an object's name has been provided to be removed
+                    objects = []
+                    for obj in self.sourceNetworks['objects']:
+                        if obj['name'] != name:
+                            objects.append(obj)
+                    self.sourceNetworks['objects'] = objects
+                    logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(name))
+                else:
+                    # a literal value has been provided to be removed
+                    literals = []
+                    for litr in self.sourceNetworks['literals']:
+                        if litr['value'] != literal['value']:
+                            literals.append(litr)
+                    self.sourceNetworks['literals'] = literals
+                    logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
             else:
                 logging.info("sourceNetworks doesn't exist for this ACPRule.  Nothing to remove.")
         elif action == 'clear':

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4548,10 +4548,10 @@ class ACPRule(APIClassTemplate):
             json_data['vlanTags'] = self.vlanTags
         if 'sourceNetworks' in self.__dict__:
             json_data['sourceNetworks'] = {'objects': self.sourceNetworks['objects']}
-            json_data['sourceNetworks']['literals'] = [{'type': k, 'value': v} for k, v in enumerate(self.sourceNetworks['literals'])]
+            json_data['sourceNetworks']['literals'] = [{'type': v, 'value': k} for k, v in self.sourceNetworks['literals'].items()]
         if 'destinationNetworks' in self.__dict__:
             json_data['destinationNetworks'] = {'objects': self.destinationNetworks['objects']}
-            json_data['destinationNetworks']['literals'] = [{'type': k, 'value': v} for k, v in enumerate(self.destinationNetworks['literals'])]
+            json_data['destinationNetworks']['literals'] = [{'type': v, 'value': k} for k, v in self.destinationNetworks['literals'].items()]
         if 'sourcePorts' in self.__dict__:
             json_data['sourcePorts'] = self.sourcePorts
         if 'destinationPorts' in self.__dict__:

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4955,17 +4955,25 @@ class ACPRule(APIClassTemplate):
                     logging.warning('Network "{}" is not found in FMC.  Cannot add to sourceNetworks.'.format(name))
                 else:
                     if 'sourceNetworks' in self.__dict__:
-                        duplicate = False
-                        for obj in self.sourceNetworks['objects']:
-                            if obj['name'] == new_net['name']:
-                                duplicate = True
-                                break
-                        if not duplicate:
-                            self.sourceNetworks['objects'].append(new_net)
+                        # thus either some objects are already present in sourceNetworks,
+                        # or only literals are present in sourceNetworks
+                        if 'objects' in self.__dict__['sourceNetworks']:
+
+                            duplicate = False
+                            for obj in self.sourceNetworks['objects']:
+                                if obj['name'] == new_net['name']:
+                                    duplicate = True
+                                    break
+                            if not duplicate:
+                                self.sourceNetworks['objects'].append(new_net)
+                                logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(name))
+                        else:
+                            self.sourceNetworks.update({'objects': [new_net]})
                             logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(name))
                     else:
                         self.sourceNetworks = {'objects': [new_net]}
                         logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(name))
+
         elif action == 'remove':
             if 'sourceNetworks' in self.__dict__:
                 objects = []

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4948,7 +4948,7 @@ class ACPRule(APIClassTemplate):
             if literal:
                 type_ = get_networkaddress_type(literal)
                 self.sourceNetworks['literals'][literal] = type_
-                logging.info('Adding literal "{}" of type "{}" to sourceNetworks for this ACPRule.', literal, type_)
+                logging.info('Adding literal "{}" of type "{}" to sourceNetworks for this ACPRule.'.format(literal, type_))
 
             else:
                 ipaddresses_json = IPAddresses(fmc=self.fmc).get()
@@ -5011,9 +5011,9 @@ class ACPRule(APIClassTemplate):
                     type_ = self.sourceNetworks['literals'].get(literal)
                     if type_:
                         self.sourceNetworks['literals'].pop(literal)
-                        logging.info('Removed literal "{}" of type "{}" from sourceNetworks for this ACPRule.', literal, type_)
+                        logging.info('Removed literal "{}" of type "{}" from sourceNetworks for this ACPRule.'.format(literal, type_))
                     else:
-                        logging.info('Unable to removed literal "{}" from sourceNetworks as it was not found', literal)
+                        logging.info('Unable to removed literal "{}" from sourceNetworks as it was not found'.format(literal))
             else:
                 logging.info("sourceNetworks doesn't exist for this ACPRule.  Nothing to remove.")
         elif action == 'clear':
@@ -5046,7 +5046,7 @@ class ACPRule(APIClassTemplate):
             if literal:
                 type_ = get_networkaddress_type(literal)
                 self.destinationNetworks['literals'][literal] = type_
-                logging.info('Adding literal "{}" of type "{}" to destinationNetworks for this ACPRule.', literal, type_)
+                logging.info('Adding literal "{}" of type "{}" to destinationNetworks for this ACPRule.'.format(literal, type_))
 
             else:
                 ipaddresses_json = IPAddresses(fmc=self.fmc).get()
@@ -5108,9 +5108,9 @@ class ACPRule(APIClassTemplate):
                     type_ = self.destinationNetworks['literals'].get(literal)
                     if type_:
                         self.destinationNetworks['literals'].pop(literal)
-                        logging.info('Removed literal "{}" of type "{}" from destinationNetworks for this ACPRule.', literal, type_)
+                        logging.info('Removed literal "{}" of type "{}" from destinationNetworks for this ACPRule.'.format(literal, type_))
                     else:
-                        logging.info('Unable to removed literal "{}" from destinationNetworks as it was not found', literal)
+                        logging.info('Unable to removed literal "{}" from destinationNetworks as it was not found'.format(literal))
             else:
                 logging.info("destinationNetworks doesn't exist for this ACPRule.  Nothing to remove.")
         elif action == 'clear':

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4999,6 +4999,7 @@ class ACPRule(APIClassTemplate):
                         if obj['name'] != name:
                             objects.append(obj)
                     if len(objects) == 0:
+                        # it was the last object which was deleted now
                         del self.sourceNetworks
                         logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
                         logging.info('All Source Networks removed from this ACPRule object.')
@@ -5012,6 +5013,7 @@ class ACPRule(APIClassTemplate):
                         if litr['value'] != literal['value']:
                             literals.append(litr)
                     if len(literals) == 0:
+                        # it was the last literal which was deleted now
                         del self.sourceNetworks
                         logging.info('Removed "{}" from sourceNetworks for this ACPRule.'.format(literal['value']))
                         logging.info('All Source Networks removed from this ACPRule object.')

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4958,8 +4958,10 @@ class ACPRule(APIClassTemplate):
                         # thus either some objects are already present in sourceNetworks,
                         # or only literals are present in sourceNetworks
                         if 'objects' in self.__dict__['sourceNetworks']:
-
+                            # some objects are already present
                             duplicate = False
+                            # see if its a duplicate or not. If not, append to the list of
+                            # existing objects in sourceNetworks
                             for obj in self.sourceNetworks['objects']:
                                 if obj['name'] == new_net['name']:
                                     duplicate = True
@@ -4968,9 +4970,15 @@ class ACPRule(APIClassTemplate):
                                 self.sourceNetworks['objects'].append(new_net)
                                 logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(name))
                         else:
+                            # this means no objects were present in sourceNetworks,
+                            # and sourceNetworks contains literals only
                             self.sourceNetworks.update({'objects': [new_net]})
+                            # So update the sourceNetworks dict which contained 'literals' key initially
+                            # to have a 'objects' key as well
                             logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(name))
                     else:
+                        # None of literals or objects are present in sourceNetworks,
+                        # so initialize it with objects and update the provided object
                         self.sourceNetworks = {'objects': [new_net]}
                         logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(name))
 

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4913,11 +4913,15 @@ class ACPRule(APIClassTemplate):
             raise ValueError('Only one of literals or name (object name) should be set while creating a source network')
 
         if action == 'add':
-            if literal != dict():
-                # some value of literal is present
+            if literal != dict():  # This means some value of literal is provided
                 if 'sourceNetworks' in self.__dict__:
+                    # thus either some literals are already present in sourceNetworks,
+                    # or only objects are present in sourceNetworks
                     if 'literals' in self.__dict__['sourceNetworks']:
+                        # some literals are already present
                         duplicate = False
+                        # see if its a duplicate or not. If not, append to the list of
+                        # existing literals in sourceNetworks
                         for litr in self.sourceNetworks['literals']:
                             if litr['value'] == literal['value']:
                                 duplicate = True
@@ -4926,9 +4930,15 @@ class ACPRule(APIClassTemplate):
                             self.sourceNetworks['literals'].append(literal)
                             logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
                     else:
+                        # this means no literals were present in sourceNetworks,
+                        # and sourceNetworks contains objects only
                         self.sourceNetworks.update({'literals':[literal]})
+                        # So update the sourceNetworks dict which contained 'objects' key initially
+                        # to have a 'literals' key as well
                         logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
                 else:
+                    # None of literals or objects are present in sourceNetworks,
+                    # so initialize it to literals and update the provided literal
                     self.sourceNetworks = {'literals': [literal]}
                     logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
             else:

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -5111,12 +5111,34 @@ class ACPRule(APIClassTemplate):
                         logging.info('Adding "{}" to destinationNetworks for this ACPRule.'.format(name))
         elif action == 'remove':
             if 'destinationNetworks' in self.__dict__:
-                objects = []
-                for obj in self.destinationNetworks['objects']:
-                    if obj['name'] != name:
-                        objects.append(obj)
-                self.destinationNetworks['objects'] = objects
-                logging.info('Removed "{}" from destinationNetworks for this ACPRule.'.format(name))
+                if name != '':
+                    # an object's name has been provided to be removed
+                    objects = []
+                    for obj in self.destinationNetworks['objects']:
+                        if obj['name'] != name:
+                            objects.append(obj)
+                    if len(objects) == 0:
+                        # it was the last object which was deleted now
+                        del self.destinationNetworks
+                        logging.info('Removed "{}" from destinationNetworks for this ACPRule'.format(name))
+                        logging.info('All Destination Networks removed from this ACPRule object.')
+                    else:
+                        self.destinationNetworks['objects'] = objects
+                        logging.info('Removed "{}" from destinationNetworks for this ACPRule.'.format(name))
+                else:
+                    # a literal value has been provided to be removed
+                    literals = []
+                    for litr in self.destinationNetworks['literals']:
+                        if litr['value'] != literal['value']:
+                            literals.append(litr)
+                    if len(literals) == 0:
+                        # it was the last literal which was deleted now
+                        del self.destinationNetworks
+                        logging.info('Removed "{}" from destinationNetworks for this ACPRule.'.format(literal['value']))
+                        logging.info('All Destination Networks removed from this ACPRule object.')
+                    else:
+                        self.destinationNetworks['literals'] = literals
+                        logging.info('Removed "{}" from destinationNetworks for this ACPRule.'.format(literal['value']))
             else:
                 logging.info("destinationNetworks doesn't exist for this ACPRule.  Nothing to remove.")
         elif action == 'clear':

--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -4906,16 +4906,27 @@ class ACPRule(APIClassTemplate):
                 del self.destinationPorts
                 logging.info('All Destination Ports removed from this ACPRule object.')
 
-    def source_network(self, action, name='', literals=tuple()):
+    def source_network(self, action, name='', literal=dict()):
+        # using dict() as default value is dangerous here, any thoughts/workarounds on this?
         logging.debug("In source_network() for ACPRule class.")
-
-        if literals != tuple() and name != '':
+        if literal != '' and name != '':
             raise ValueError('Only one of literals or name (object name) should be set while creating a source network')
 
         if action == 'add':
-
-            if len(literals) < 0:
-                pass
+            if literal != dict():
+                # some value of literal is present
+                if 'sourceNetworks' in self.__dict__:
+                    duplicate = False
+                    for litr in self.sourceNetworks['literals']:
+                        if litr['value'] == literal['value']:
+                            duplicate = True
+                            break
+                    if not duplicate:
+                        self.sourceNetworks['literals'].append(literal)
+                        logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
+                else:
+                    self.sourceNetworks = {'literals': [literal]}
+                    logging.info('Adding "{}" to sourceNetworks for this ACPRule.'.format(literal))
             else:
                 ipaddresses_json = IPAddresses(fmc=self.fmc).get()
                 networkgroup_json = NetworkGroup(fmc=self.fmc).get()

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -323,7 +323,6 @@ class TestApiObjects(unittest.TestCase):
                          {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
                           'type': 'someExistingObjectType1'})
 
-
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -304,3 +304,21 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
         self.assertEqual(rule_obj.sourceNetworks['literals'][2],
                          {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_for_literals_and_objects_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 1)
+        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][1],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -425,5 +425,16 @@ class TestApiObjects(unittest.TestCase):
             {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
             {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
         }
-        rule_obj.source_network(action='clear', name='someExistingObjectName3')
+        rule_obj.source_network(action='clear')
+        self.assertNotIn('sourceNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_clear_for_literals(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
+        }
+        rule_obj.source_network(action='clear')
         self.assertNotIn('sourceNetworks', self.__dict__)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -416,3 +416,14 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(rule_obj.sourceNetworks['objects'][1],
                          {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
                           'type': 'someExistingObjectType2'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_clear_for_objects(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'objects': [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        }
+        rule_obj.source_network(action='clear', name='someExistingObjectName3')
+        self.assertNotIn('sourceNetworks', self.__dict__)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -122,7 +122,8 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_with_no_initial_sourceNetworks(self, mock_ipaddress, mock_fqdns, mock_nwgroup, _):
+    def test_ACPRule_source_network_with_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns,
+                                                                              mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -362,3 +362,8 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(rule_obj.sourceNetworks['literals'][2],
                          {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
 
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_with_both_name_and_literals_given(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        with self.assertRaises(ValueError):
+            rule_obj.source_network(action='add', name='someObjectName', literal={'type':'someType', 'value':'someValue'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -172,3 +172,34 @@ class TestApiObjects(unittest.TestCase):
         rule_obj.source_network(action='add', name='someExistingObjectName2')
         self.assertEqual(len(rule_obj.sourceNetworks['objects']), 2)
         self.assertEqual(rule_obj.sourceNetworks['objects'][0], {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_source_network_for_objects_and_multiple_objects_present_initially(self, mock_ipaddress, mock_fqdns,
+                                                                              mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}
+        ]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.sourceNetworks['objects']), 3)
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0], {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -133,8 +133,7 @@ class TestApiObjects(unittest.TestCase):
         value2.get.return_value = [
             {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
             {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
-            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}
-        ]
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
         mock_ipaddress.return_value = value
         mock_nwgroup.return_value = dummyvalue3
         mock_fqdns.return_value = dummyvalue3
@@ -143,8 +142,4 @@ class TestApiObjects(unittest.TestCase):
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', name='someExistingObjectName2')
         self.assertEqual(rule_obj.sourceNetworks, {'objects': [
-            {'name': 'someExistingObjectName2',
-             'id': 'someExistingObjectId2',
-             'type': 'someExistingObjectType2'}]
-            }
-        )
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'}]})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -382,3 +382,12 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
         self.assertEqual(rule_obj.sourceNetworks['literals'][1],
                          {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_remove_for_literals_with_only_one_literal_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value': 'someLiteralValue2'}]
+        }
+        rule_obj.source_network(action='remove', literal={'value':'someLiteralValue2'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 0)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -175,6 +175,9 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(rule_obj.sourceNetworks['objects'][0],
                          {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
                           'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][1],
+                         {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
+                          'type': 'someExistingObjectType2'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     @mock.patch('fmcapi.api_objects.NetworkGroup')

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -119,7 +119,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns, mock_nwgroup,
+    def test_ACPRule_source_network_add_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns, mock_nwgroup,
                                                                          _):
         value2 = mock.Mock()
         value = mock.Mock()
@@ -147,7 +147,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_for_objects_and_one_objects_present_initially(self, mock_ipaddress, mock_fqdns,
+    def test_ACPRule_source_network_add_for_objects_and_one_objects_present_initially(self, mock_ipaddress, mock_fqdns,
                                                                                   mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
@@ -180,7 +180,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_for_objects_and_multiple_objects_present_initially(self, mock_ipaddress, mock_fqdns,
+    def test_ACPRule_source_network_add_for_objects_and_multiple_objects_present_initially(self, mock_ipaddress, mock_fqdns,
                                                                                        mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
@@ -217,7 +217,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_for_objects_and_duplicate_objects_present(self, mock_ipaddress, mock_fqdns,
+    def test_ACPRule_source_network_add_for_objects_and_duplicate_objects_present(self, mock_ipaddress, mock_fqdns,
                                                                               mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
@@ -248,7 +248,7 @@ class TestApiObjects(unittest.TestCase):
                           'type': 'someExistingObjectType1'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
-    def test_ACPRule_source_network_for_literals_and_no_literal_present_initially(self, _):
+    def test_ACPRule_source_network_add_for_literals_and_no_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         # rule_obj.sourceNetworks = {'objects': [
         #     {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
@@ -260,7 +260,7 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
-    def test_ACPRule_source_network_for_literals_and_one_literal_present_initially(self, _):
+    def test_ACPRule_source_network_add_for_literals_and_one_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
@@ -272,7 +272,7 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
-    def test_ACPRule_source_network_for_literals_and_multiple_literal_present_initially(self, _):
+    def test_ACPRule_source_network_add_for_literals_and_multiple_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
             {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
@@ -290,7 +290,7 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
-    def test_ACPRule_source_network_for_literals_and_duplicate_literal_present(self, _):
+    def test_ACPRule_source_network_add_for_literals_and_duplicate_literal_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
             {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
@@ -306,7 +306,7 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
-    def test_ACPRule_source_network_for_literals_and_objects_present_initially(self, _):
+    def test_ACPRule_source_network_add_for_literals_and_objects_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.sourceNetworks = {'objects': [
             {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
@@ -328,7 +328,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_for_objects_and_literals_present_initially(self, mock_ipaddress, mock_fqdns,
+    def test_ACPRule_source_network_add_for_objects_and_literals_present_initially(self, mock_ipaddress, mock_fqdns,
                                                                               mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -492,8 +492,9 @@ class TestApiObjects(unittest.TestCase):
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.destination_network(action='add', name='someExistingObjectName2')
         self.assertEqual(len(rule_obj.destinationNetworks['objects']), 1)
-        self.assertEqual(rule_obj.destinationNetworks, {'objects': [
-            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'}]})
+        self.assertEqual(rule_obj.destinationNetworks['objects'], [{'name': 'someExistingObjectName2',
+                                                                    'id'  : 'someExistingObjectId2',
+                                                                    'type': 'someExistingObjectType2'}])
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     @mock.patch('fmcapi.api_objects.NetworkGroup')
@@ -602,72 +603,52 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_add_for_literals_and_no_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        # rule_obj.destinationNetworks = {'objects': [
-        #     {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
-        #     {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        rule_obj.destination_network(action='add', literal='10.0.0.1')
         self.assertEqual(len(rule_obj.destinationNetworks['literals']), 1)
-        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.1'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_add_for_literals_and_one_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'}]}
+        rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        rule_obj.destination_network(action='add', literal='10.0.0.2')
         self.assertEqual(len(rule_obj.destinationNetworks['literals']), 2)
-        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.1'], 'host')
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.2'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_add_for_literals_and_multiple_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host', '10.0.0.2': 'host', '10.0.0.3': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        rule_obj.destination_network(action='add', literal='10.0.0.4')
         self.assertEqual(len(rule_obj.destinationNetworks['literals']), 4)
-        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][2],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][3],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.1'], 'host')
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.2'], 'host')
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.3'], 'host')
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.4'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_add_for_literals_and_duplicate_literal_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
-        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 3)
-        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][2],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        rule_obj.destination_network(action='add', literal='10.0.0.1')
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 1)
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_add_for_literals_and_objects_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.destinationNetworks = {'objects': [
             {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
-            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}],
+            'literals': {}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        rule_obj.destination_network(action='add', literal="10.0.0.1")
         self.assertEqual(len(rule_obj.destinationNetworks['literals']), 1)
-        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.1'], 'host')
         self.assertEqual(rule_obj.destinationNetworks['objects'][0],
                          {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
                           'type': 'someExistingObjectType3'})
@@ -696,52 +677,37 @@ class TestApiObjects(unittest.TestCase):
         mock_nwgroup.return_value = dummyvalue3
         mock_fqdns.return_value = dummyvalue3
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.destination_network(action='add', name='someExistingObjectName3')
         self.assertEqual(len(rule_obj.destinationNetworks['objects']), 1)
         self.assertEqual(rule_obj.destinationNetworks['objects'][0],
                          {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
                           'type': 'someExistingObjectType3'})
-        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 3)
-        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][2],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 1)
+        self.assertEqual(rule_obj.destinationNetworks['literals']['10.0.0.1'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_with_both_name_and_literals_given(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         with self.assertRaises(ValueError):
-            rule_obj.destination_network(action='add', name='someObjectName', literal={'type':'someType', 'value':'someValue'})
+            rule_obj.destination_network(action='add', name='someObjectName', literal='10.0.0.1')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_remove_for_literals_with_multiple_literals_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.destinationNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
-        }
-        rule_obj.destination_network(action='remove', literal={'value':'someLiteralValue3'})
+        rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host', '10.0.0.2': 'host', '10.0.0.3': 'host'}}
+        rule_obj.destination_network(action='remove', literal='10.0.0.1')
         self.assertEqual(len(rule_obj.destinationNetworks['literals']), 2)
-        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertIsNotNone(rule_obj.destinationNetworks['literals']['10.0.0.2'])
+        self.assertIsNotNone(rule_obj.destinationNetworks['literals']['10.0.0.3'])
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_remove_for_literals_with_only_one_literal_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.destinationNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value': 'someLiteralValue2'}]
-        }
-        rule_obj.destination_network(action='remove', literal={'value':'someLiteralValue2'})
-        self.assertNotIn('destinationNetworks', self.__dict__)
+        rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host'}}
+        rule_obj.destination_network(action='remove', literal='10.0.0.1')
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 0)
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_remove_for_objects_with_only_one_object_present(self, _):
@@ -783,10 +749,6 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_destination_network_clear_for_literals(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.destinationNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
-        }
+        rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.destination_network(action='clear')
         self.assertNotIn('destinationNetworks', self.__dict__)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -217,6 +217,40 @@ class TestApiObjects(unittest.TestCase):
                           'type': 'someExistingObjectType2'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_source_network_for_objects_and_duplicate_objects_present(self, mock_ipaddress, mock_fqdns,
+                                                                                       mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', name='someExistingObjectName3')
+        self.assertEqual(len(rule_obj.sourceNetworks['objects']), 2)
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][1],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_for_literals_and_no_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         # rule_obj.sourceNetworks = {'objects': [

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -142,6 +142,7 @@ class TestApiObjects(unittest.TestCase):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.sourceNetworks['objects']), 1)
         self.assertEqual(rule_obj.sourceNetworks, {'objects': [
             {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'}]})
 

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -150,7 +150,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_for_objects_and_some_objects_present_initially(self, mock_ipaddress, mock_fqdns,
-                                                                              mock_nwgroup, _):
+                                                                                   mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -165,20 +165,22 @@ class TestApiObjects(unittest.TestCase):
         mock_ipaddress.return_value = value
         mock_nwgroup.return_value = dummyvalue3
         mock_fqdns.return_value = dummyvalue3
-
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'objects': [{'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]}
+        rule_obj.sourceNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', name='someExistingObjectName2')
         self.assertEqual(len(rule_obj.sourceNetworks['objects']), 2)
-        self.assertEqual(rule_obj.sourceNetworks['objects'][0], {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_for_objects_and_multiple_objects_present_initially(self, mock_ipaddress, mock_fqdns,
-                                                                              mock_nwgroup, _):
+                                                                                       mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -193,13 +195,13 @@ class TestApiObjects(unittest.TestCase):
         mock_ipaddress.return_value = value
         mock_nwgroup.return_value = dummyvalue3
         mock_fqdns.return_value = dummyvalue3
-
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.sourceNetworks = {'objects': [
             {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
-            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}
-        ]}
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', name='someExistingObjectName2')
         self.assertEqual(len(rule_obj.sourceNetworks['objects']), 3)
-        self.assertEqual(rule_obj.sourceNetworks['objects'][0], {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -144,3 +144,31 @@ class TestApiObjects(unittest.TestCase):
         rule_obj.source_network(action='add', name='someExistingObjectName2')
         self.assertEqual(rule_obj.sourceNetworks, {'objects': [
             {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'}]})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_source_network_for_objects_and_some_objects_present_initially(self, mock_ipaddress, mock_fqdns,
+                                                                              mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'objects': [{'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.sourceNetworks['objects']), 2)
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0], {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -389,4 +389,4 @@ class TestApiObjects(unittest.TestCase):
             {'type': 'someLiteralType', 'value': 'someLiteralValue2'}]
         }
         rule_obj.source_network(action='remove', literal={'value':'someLiteralValue2'})
-        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 0)
+        self.assertNotIn('sourceNetworks', self.__dict__)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -438,3 +438,31 @@ class TestApiObjects(unittest.TestCase):
         }
         rule_obj.source_network(action='clear')
         self.assertNotIn('sourceNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_destination_network_add_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns, mock_nwgroup,
+                                                                         _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.destinationNetworks['objects']), 1)
+        self.assertEqual(rule_obj.destinationNetworks, {'objects': [
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'}]})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -399,3 +399,20 @@ class TestApiObjects(unittest.TestCase):
         }
         rule_obj.source_network(action='remove', name='someExistingObjectName1')
         self.assertNotIn('sourceNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_remove_for_objects_with_multiple_objects_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'objects': [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        }
+        rule_obj.source_network(action='remove', name='someExistingObjectName3')
+        self.assertEqual(len(rule_obj.sourceNetworks['objects']), 2)
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][1],
+                         {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
+                          'type': 'someExistingObjectType2'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -296,3 +296,22 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
         self.assertEqual(rule_obj.sourceNetworks['literals'][3],
                          {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_for_literals_and_duplicate_literal_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value':'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}
+        ]
+        }
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 3)
+        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][2],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -122,7 +122,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_with_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns,
+    def test_ACPRule_source_network_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns,
                                                                               mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -215,3 +215,15 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(rule_obj.sourceNetworks['objects'][2],
                          {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
                           'type': 'someExistingObjectType2'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_for_literals_and_no_literal_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        # rule_obj.sourceNetworks = {'objects': [
+        #     {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+        #     {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 1)
+        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -117,3 +117,34 @@ class TestApiObjects(unittest.TestCase):
 
         self.assertTrue(a.URL.endswith('?category=something&insertBefore=something&insertAfter=something'))
         mock_log.assert_called_once()
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_source_network_with_no_initial_sourceNetworks(self, mock_ipaddress, mock_fqdns, mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}
+        ]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(rule_obj.sourceNetworks, {'objects': [
+            {'name': 'someExistingObjectName2',
+             'id': 'someExistingObjectId2',
+             'type': 'someExistingObjectType2'}]
+            }
+        )

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -390,3 +390,12 @@ class TestApiObjects(unittest.TestCase):
         }
         rule_obj.source_network(action='remove', literal={'value':'someLiteralValue2'})
         self.assertNotIn('sourceNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_remove_for_objects_with_only_one_object_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'objects': [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]
+        }
+        rule_obj.source_network(action='remove', name='someExistingObjectName1')
+        self.assertNotIn('sourceNetworks', self.__dict__)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -758,3 +758,12 @@ class TestApiObjects(unittest.TestCase):
                                                                              })
         self.assertEqual([{'name': 'someExistingObjectName1'}], rule_obj.destinationNetworks['objects'])
         self.assertEqual({'10.0.0.1': 'host'}, rule_obj.destinationNetworks['literals'])
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_format_data_with_source_networks(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock(), sourceNetworks={'objects' : [{'name': 'someExistingObjectName1'}],
+                                                                        'literals': [{'type': 'host', 'value': '10.0.0.1'}]
+                                                                        })
+        data = rule_obj.format_data()
+        self.assertEqual([{'name': 'someExistingObjectName1'}], data['sourceNetworks']['objects'])
+        self.assertEqual([{'type': 'host', 'value': '10.0.0.1'}], data['sourceNetworks']['literals'])

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -209,3 +209,9 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(rule_obj.sourceNetworks['objects'][0],
                          {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
                           'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][1],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})
+        self.assertEqual(rule_obj.sourceNetworks['objects'][2],
+                         {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
+                          'type': 'someExistingObjectType2'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -120,7 +120,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_add_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns, mock_nwgroup,
-                                                                         _):
+                                                                             _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -147,8 +147,37 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_source_network_add_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns, mock_nwgroup,
+                                                                             _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.sourceNetworks['objects']), 1)
+        self.assertEqual(rule_obj.sourceNetworks['objects'], [{'name': 'someExistingObjectName2',
+                                                               'id'  : 'someExistingObjectId2',
+                                                               'type': 'someExistingObjectType2'}])
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_add_for_objects_and_one_objects_present_initially(self, mock_ipaddress, mock_fqdns,
-                                                                                  mock_nwgroup, _):
+                                                                                      mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -181,7 +210,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_add_for_objects_and_multiple_objects_present_initially(self, mock_ipaddress, mock_fqdns,
-                                                                                       mock_nwgroup, _):
+                                                                                           mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -218,7 +247,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_add_for_objects_and_duplicate_objects_present(self, mock_ipaddress, mock_fqdns,
-                                                                              mock_nwgroup, _):
+                                                                                  mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -250,72 +279,52 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_add_for_literals_and_no_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        # rule_obj.sourceNetworks = {'objects': [
-        #     {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
-        #     {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        rule_obj.source_network(action='add', literal='10.0.0.1')
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 1)
-        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.1'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_add_for_literals_and_one_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'}]}
+        rule_obj.sourceNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        rule_obj.source_network(action='add', literal='10.0.0.2')
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 2)
-        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.1'], 'host')
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.2'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_add_for_literals_and_multiple_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.sourceNetworks = {'literals': {'10.0.0.1': 'host', '10.0.0.2': 'host', '10.0.0.3': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        rule_obj.source_network(action='add', literal='10.0.0.4')
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 4)
-        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][2],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][3],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.1'], 'host')
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.2'], 'host')
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.3'], 'host')
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.4'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_add_for_literals_and_duplicate_literal_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.sourceNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
-        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 3)
-        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][2],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        rule_obj.source_network(action='add', literal='10.0.0.1')
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 1)
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_add_for_literals_and_objects_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         rule_obj.sourceNetworks = {'objects': [
             {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
-            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}],
+            'literals'                      : {}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
-        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        rule_obj.source_network(action='add', literal="10.0.0.1")
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 1)
-        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.1'], 'host')
         self.assertEqual(rule_obj.sourceNetworks['objects'][0],
                          {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
                           'type': 'someExistingObjectType3'})
@@ -328,7 +337,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_add_for_objects_and_literals_present_initially(self, mock_ipaddress, mock_fqdns,
-                                                                              mock_nwgroup, _):
+                                                                                   mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -344,52 +353,37 @@ class TestApiObjects(unittest.TestCase):
         mock_nwgroup.return_value = dummyvalue3
         mock_fqdns.return_value = dummyvalue3
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.sourceNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', name='someExistingObjectName3')
         self.assertEqual(len(rule_obj.sourceNetworks['objects']), 1)
         self.assertEqual(rule_obj.sourceNetworks['objects'][0],
                          {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
                           'type': 'someExistingObjectType3'})
-        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 3)
-        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][2],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 1)
+        self.assertEqual(rule_obj.sourceNetworks['literals']['10.0.0.1'], 'host')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_with_both_name_and_literals_given(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         with self.assertRaises(ValueError):
-            rule_obj.source_network(action='add', name='someObjectName', literal={'type':'someType', 'value':'someValue'})
+            rule_obj.source_network(action='add', name='someObjectName', literal='10.0.0.1')
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_remove_for_literals_with_multiple_literals_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
-        }
-        rule_obj.source_network(action='remove', literal={'value':'someLiteralValue3'})
+        rule_obj.sourceNetworks = {'literals': {'10.0.0.1': 'host', '10.0.0.2': 'host', '10.0.0.3': 'host'}}
+        rule_obj.source_network(action='remove', literal='10.0.0.1')
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 2)
-        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
-        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
-                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertIsNotNone(rule_obj.sourceNetworks['literals']['10.0.0.2'])
+        self.assertIsNotNone(rule_obj.sourceNetworks['literals']['10.0.0.3'])
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_remove_for_literals_with_only_one_literal_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value': 'someLiteralValue2'}]
-        }
-        rule_obj.source_network(action='remove', literal={'value':'someLiteralValue2'})
-        self.assertNotIn('sourceNetworks', self.__dict__)
+        rule_obj.sourceNetworks = {'literals': {'10.0.0.1': 'host'}}
+        rule_obj.source_network(action='remove', literal='10.0.0.1')
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 0)
 
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_remove_for_objects_with_only_one_object_present(self, _):
@@ -431,11 +425,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_clear_for_literals(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
-        }
+        rule_obj.sourceNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.source_network(action='clear')
         self.assertNotIn('sourceNetworks', self.__dict__)
 

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -466,3 +466,327 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(len(rule_obj.destinationNetworks['objects']), 1)
         self.assertEqual(rule_obj.destinationNetworks, {'objects': [
             {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'}]})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_destination_network_add_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns, mock_nwgroup,
+                                                                         _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.destinationNetworks['objects']), 1)
+        self.assertEqual(rule_obj.destinationNetworks, {'objects': [
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'}]})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_destination_network_add_for_objects_and_one_objects_present_initially(self, mock_ipaddress, mock_fqdns,
+                                                                                  mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.destinationNetworks['objects']), 2)
+        self.assertEqual(rule_obj.destinationNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.destinationNetworks['objects'][1],
+                         {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
+                          'type': 'someExistingObjectType2'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_destination_network_add_for_objects_and_multiple_objects_present_initially(self, mock_ipaddress, mock_fqdns,
+                                                                                       mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', name='someExistingObjectName2')
+        self.assertEqual(len(rule_obj.destinationNetworks['objects']), 3)
+        self.assertEqual(rule_obj.destinationNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.destinationNetworks['objects'][1],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})
+        self.assertEqual(rule_obj.destinationNetworks['objects'][2],
+                         {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
+                          'type': 'someExistingObjectType2'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_destination_network_add_for_objects_and_duplicate_objects_present(self, mock_ipaddress, mock_fqdns,
+                                                                              mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', name='someExistingObjectName3')
+        self.assertEqual(len(rule_obj.destinationNetworks['objects']), 2)
+        self.assertEqual(rule_obj.destinationNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.destinationNetworks['objects'][1],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_add_for_literals_and_no_literal_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        # rule_obj.destinationNetworks = {'objects': [
+        #     {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+        #     {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 1)
+        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_add_for_literals_and_one_literal_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 2)
+        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_add_for_literals_and_multiple_literal_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 4)
+        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][2],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][3],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_add_for_literals_and_duplicate_literal_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 3)
+        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][2],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_add_for_literals_and_objects_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'objects': [
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'},
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 1)
+        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(rule_obj.destinationNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(rule_obj.destinationNetworks['objects'][1],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_destination_network_add_for_objects_and_literals_present_initially(self, mock_ipaddress, mock_fqdns,
+                                                                              mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.destination_network(action='add', name='someExistingObjectName3')
+        self.assertEqual(len(rule_obj.destinationNetworks['objects']), 1)
+        self.assertEqual(rule_obj.destinationNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 3)
+        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][2],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_with_both_name_and_literals_given(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        with self.assertRaises(ValueError):
+            rule_obj.destination_network(action='add', name='someObjectName', literal={'type':'someType', 'value':'someValue'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_remove_for_literals_with_multiple_literals_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
+        }
+        rule_obj.destination_network(action='remove', literal={'value':'someLiteralValue3'})
+        self.assertEqual(len(rule_obj.destinationNetworks['literals']), 2)
+        self.assertEqual(rule_obj.destinationNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.destinationNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_remove_for_literals_with_only_one_literal_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value': 'someLiteralValue2'}]
+        }
+        rule_obj.destination_network(action='remove', literal={'value':'someLiteralValue2'})
+        self.assertNotIn('destinationNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_remove_for_objects_with_only_one_object_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'objects': [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'}]
+        }
+        rule_obj.destination_network(action='remove', name='someExistingObjectName1')
+        self.assertNotIn('destinationNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_remove_for_objects_with_multiple_objects_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'objects': [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        }
+        rule_obj.destination_network(action='remove', name='someExistingObjectName3')
+        self.assertEqual(len(rule_obj.destinationNetworks['objects']), 2)
+        self.assertEqual(rule_obj.destinationNetworks['objects'][0],
+                         {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
+                          'type': 'someExistingObjectType1'})
+        self.assertEqual(rule_obj.destinationNetworks['objects'][1],
+                         {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2',
+                          'type': 'someExistingObjectType2'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_clear_for_objects(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'objects': [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        }
+        rule_obj.destination_network(action='clear')
+        self.assertNotIn('destinationNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_destination_network_clear_for_literals(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.destinationNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
+        }
+        rule_obj.destination_network(action='clear')
+        self.assertNotIn('destinationNetworks', self.__dict__)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -109,10 +109,7 @@ class TestApiObjects(unittest.TestCase):
             - insertBefore param
             - insertAfter param
         """
-        a = api_objects.ACPRule(fmc=mock_fmc,
-                                acp_name='something',
-                                category='something',
-                                insertBefore='something',
+        a = api_objects.ACPRule(fmc=mock_fmc, acp_name='something', category='something', insertBefore='something',
                                 insertAfter='something')
 
         self.assertTrue(a.URL.endswith('?category=something&insertBefore=something&insertAfter=something'))
@@ -122,8 +119,8 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns,
-                                                                              mock_nwgroup, _):
+    def test_ACPRule_source_network_for_objects_and_no_objects_initially(self, mock_ipaddress, mock_fqdns, mock_nwgroup,
+                                                                         _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -151,7 +148,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_for_objects_and_one_objects_present_initially(self, mock_ipaddress, mock_fqdns,
-                                                                                   mock_nwgroup, _):
+                                                                                  mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -221,7 +218,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
     def test_ACPRule_source_network_for_objects_and_duplicate_objects_present(self, mock_ipaddress, mock_fqdns,
-                                                                                       mock_nwgroup, _):
+                                                                              mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()
         value.get.return_value = value2
@@ -265,9 +262,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_for_literals_and_one_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value':'someLiteralValue2'}]
-        }
+        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 2)
@@ -279,12 +274,9 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_for_literals_and_multiple_literal_present_initially(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value':'someLiteralValue2'},
+        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
             {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}
-        ]
-        }
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 4)
@@ -300,12 +292,9 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
     def test_ACPRule_source_network_for_literals_and_duplicate_literal_present(self, _):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
-        rule_obj.sourceNetworks = {'literals': [
-            {'type': 'someLiteralType', 'value':'someLiteralValue2'},
+        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
             {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
-            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}
-        ]
-        }
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
         rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
         rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue4'})
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 3)

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -150,7 +150,7 @@ class TestApiObjects(unittest.TestCase):
     @mock.patch('fmcapi.api_objects.NetworkGroup')
     @mock.patch('fmcapi.api_objects.FQDNS')
     @mock.patch('fmcapi.api_objects.IPAddresses')
-    def test_ACPRule_source_network_for_objects_and_some_objects_present_initially(self, mock_ipaddress, mock_fqdns,
+    def test_ACPRule_source_network_for_objects_and_one_objects_present_initially(self, mock_ipaddress, mock_fqdns,
                                                                                    mock_nwgroup, _):
         value2 = mock.Mock()
         value = mock.Mock()

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -227,3 +227,17 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(len(rule_obj.sourceNetworks['literals']), 1)
         self.assertEqual(rule_obj.sourceNetworks['literals'][0],
                          {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_for_literals_and_one_literal_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value':'someLiteralValue2'}]
+        }
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 2)
+        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -275,3 +275,24 @@ class TestApiObjects(unittest.TestCase):
                          {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
         self.assertEqual(rule_obj.sourceNetworks['literals'][1],
                          {'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_for_literals_and_multiple_literal_present_initially(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value':'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}
+        ]
+        }
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', literal={'type': 'someLiteralType', 'value': 'someLiteralValue1'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 4)
+        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][2],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][3],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue1'})

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -742,3 +742,19 @@ class TestApiObjects(unittest.TestCase):
         rule_obj.destinationNetworks = {'literals': {'10.0.0.1': 'host'}}
         rule_obj.destination_network(action='clear')
         self.assertNotIn('destinationNetworks', self.__dict__)
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_parse_kwargs_with_source_networks(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock(), sourceNetworks={'objects' : [{'name': 'someExistingObjectName1'}],
+                                                                        'literals': [{'type': 'host', 'value': '10.0.0.1'}]
+                                                                        })
+        self.assertEqual([{'name': 'someExistingObjectName1'}], rule_obj.sourceNetworks['objects'])
+        self.assertEqual({'10.0.0.1': 'host'}, rule_obj.sourceNetworks['literals'])
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_parse_kwargs_with_destination_networks(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock(), destinationNetworks={'objects' : [{'name': 'someExistingObjectName1'}],
+                                                                             'literals': [{'type': 'host', 'value': '10.0.0.1'}]
+                                                                             })
+        self.assertEqual([{'name': 'someExistingObjectName1'}], rule_obj.destinationNetworks['objects'])
+        self.assertEqual({'10.0.0.1': 'host'}, rule_obj.destinationNetworks['literals'])

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -322,3 +322,43 @@ class TestApiObjects(unittest.TestCase):
         self.assertEqual(rule_obj.sourceNetworks['objects'][1],
                          {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1',
                           'type': 'someExistingObjectType1'})
+
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    @mock.patch('fmcapi.api_objects.NetworkGroup')
+    @mock.patch('fmcapi.api_objects.FQDNS')
+    @mock.patch('fmcapi.api_objects.IPAddresses')
+    def test_ACPRule_source_network_for_objects_and_literals_present_initially(self, mock_ipaddress, mock_fqdns,
+                                                                              mock_nwgroup, _):
+        value2 = mock.Mock()
+        value = mock.Mock()
+        value.get.return_value = value2
+        dummyvalue3 = mock.Mock()
+        dummyvalue4 = mock.Mock()
+        dummyvalue4.get.return_value = []
+        dummyvalue3.get.return_value = dummyvalue4
+        value2.get.return_value = [
+            {'name': 'someExistingObjectName1', 'id': 'someExistingObjectId1', 'type': 'someExistingObjectType1'},
+            {'name': 'someExistingObjectName2', 'id': 'someExistingObjectId2', 'type': 'someExistingObjectType2'},
+            {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3', 'type': 'someExistingObjectType3'}]
+        mock_ipaddress.return_value = value
+        mock_nwgroup.return_value = dummyvalue3
+        mock_fqdns.return_value = dummyvalue3
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'literals': [{'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]}
+        rule_obj.URL = '/accesspolicies/<accesspolicyid>/accessrules/<accessruleid>'
+        rule_obj.source_network(action='add', name='someExistingObjectName3')
+        self.assertEqual(len(rule_obj.sourceNetworks['objects']), 1)
+        self.assertEqual(rule_obj.sourceNetworks['objects'][0],
+                         {'name': 'someExistingObjectName3', 'id': 'someExistingObjectId3',
+                          'type': 'someExistingObjectType3'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 3)
+        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue3'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][2],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})
+

--- a/test/unit/test_api_objects.py
+++ b/test/unit/test_api_objects.py
@@ -367,3 +367,18 @@ class TestApiObjects(unittest.TestCase):
         rule_obj = api_objects.ACPRule(fmc=mock.Mock())
         with self.assertRaises(ValueError):
             rule_obj.source_network(action='add', name='someObjectName', literal={'type':'someType', 'value':'someValue'})
+
+    @mock.patch('fmcapi.api_objects.ACPRule.variable_set')
+    def test_ACPRule_source_network_remove_for_literals_with_multiple_literals_present(self, _):
+        rule_obj = api_objects.ACPRule(fmc=mock.Mock())
+        rule_obj.sourceNetworks = {'literals': [
+            {'type': 'someLiteralType', 'value': 'someLiteralValue2'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue3'},
+            {'type': 'someLiteralType', 'value': 'someLiteralValue4'}]
+        }
+        rule_obj.source_network(action='remove', literal={'value':'someLiteralValue3'})
+        self.assertEqual(len(rule_obj.sourceNetworks['literals']), 2)
+        self.assertEqual(rule_obj.sourceNetworks['literals'][0],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue2'})
+        self.assertEqual(rule_obj.sourceNetworks['literals'][1],
+                         {'type': 'someLiteralType', 'value': 'someLiteralValue4'})


### PR DESCRIPTION
literal support for sourceNetworks and destinationNetworks in ACPRule.
sourcePort and destinationPorts to come in next PR