### PR TITLE
allow addition of NetworGroups to NetworkGroup objects

### DIFF
--- a/fmcapi/api_objects.py
+++ b/fmcapi/api_objects.py
@@ -411,6 +411,30 @@ class NetworkGroup(APIClassTemplate):
                     else:
                         self.objects = [new_net]
                         logging.info('Adding "{}" to NetworkGroup.'.format(name))
+        if action == 'addgroup':
+            netg1 = NetworkGroup(fmc=self.fmc)
+            response = netg1.get()
+            if 'items' in response:
+                new_net = None
+                for item in response['items']:
+                    if item['name'] == name:
+                        new_net = {'name': item['name'], 'id': item['id'], 'type': item['type']}
+                        break
+                if new_net is None:
+                    logging.warning('Network "{}" is not found in FMC.  Cannot add to NetworkGroup.'.format(name))
+                else:
+                    if 'objects' in self.__dict__:
+                        duplicate = False
+                        for obj in self.objects:
+                            if obj['name'] == new_net['name']:
+                                duplicate = True
+                                break
+                        if not duplicate:
+                            self.objects.append(new_net)
+                            logging.info('Adding "{}" to NetworkGroup.'.format(name))
+                    else:
+                        self.objects = [new_net]
+                        logging.info('Adding "{}" to NetworkGroup.'.format(name))		
         elif action == 'remove':
             if 'objects' in self.__dict__:
                 objects_list = []


### PR DESCRIPTION
I put a message in under "issues" a while back about this little change I needed. I was looking to automate adding a NetworkGroup to an already defined NetworkGroup object and couldn't see a way to do it, so I made this addition to your very handy fmcapi package.

Hopefully the change makes sense and I've used git (not done commits/pushing code in years) correctly to let you review it.

Thanks