### PR TITLE
Remove feature suppression

### DIFF
--- a/fmcapi/api_objects/policy_services/accesspolicies.py
+++ b/fmcapi/api_objects/policy_services/accesspolicies.py
@@ -48,14 +48,6 @@ class AccessPolicies(APIClassTemplate):
         json_data["defaultAction"] = self.defaultAction
         return json_data
 
-    def put(self):
-        logging.info("PUT method for API for AccessPolicies not supported.")
-        pass
-
-    def delete(self):
-        logging.info("DELETE method for API for AccessPolicies not supported.")
-        pass
-
 
 class AccessControlPolicy(AccessPolicies):
     """Dispose of this Class after 20210101."""


### PR DESCRIPTION
Put and Delete of Access Policy is definitely allowed in FMC. Checked release notes back to 6.1.0 and all subsequent releases have this capability. I've Monkey Patched this feature into our own code so though it time we get it into the offical code ;-)