### PR TITLE
Changed URL_SUFFIX property return value

### DIFF
--- a/fmcapi/api_objects/policy_services/prefilterrules.py
+++ b/fmcapi/api_objects/policy_services/prefilterrules.py
@@ -86,7 +86,7 @@ class PreFilterRules(APIClassTemplate):
         elif "insertAfter" in self.__dict__:
             url = f"{url}insertAfter={self.insertAfter}"
 
-        return url
+        return url[:-1]
 
     def parse_kwargs(self, **kwargs):
         """


### PR DESCRIPTION
When performing get() on prefilterrules objects the url has an extra '?' parameter separator because it is already added before the URL_SUFFIX parameter is set. This change matches other object classes (ie. AccessRules) and removes the extra '?' before returning the url.