### PR TITLE
Include addgroup function for source_port and destination_port. Debug json dumps.

### DIFF
--- a/fmcapi/api_objects/apiclasstemplate.py
+++ b/fmcapi/api_objects/apiclasstemplate.py
@@ -177,6 +177,9 @@ class APIClassTemplate(object):
                         )
                 if "id" not in self.__dict__:
                     logging.warning(
+                        f"\tGET query for {self.name} is not found."
+                    )
+                    logging.debug(
                         f"\tGET query for {self.name} is not found.\n\t\tResponse: {json.dumps(response)}"
                     )
             else:

--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -650,7 +650,7 @@ class AccessRules(APIClassTemplate):
                     )
             else:
                 logging.warning(
-                    f'Protocol Port or Protocol Port Group: "{name}", '
+                    f'Protocol Port Port Group: "{name}", '
                     f"not found.  Cannot add to AccessRules."
                 )
         elif action == "remove":

--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -511,6 +511,38 @@ class AccessRules(APIClassTemplate):
                     f'Protocol Port or Protocol Port Group: "{name}", '
                     f"not found.  Cannot add to AccessRules."
                 )
+        elif action == "addgroup":
+            item = PortObjectGroups(fmc=self.fmc)
+            item.get(name=name)
+            if "id" in item.__dict__:
+                if "sourcePorts" in self.__dict__:
+                    new_port = {"name": item.name, "id": item.id, "type": item.type}
+                    duplicate = False
+                    if "objects" not in self.sourcePorts:
+                        self.__dict__["sourcePorts"]["objects"] = []
+                    for obj in self.sourcePorts["objects"]:
+                        if obj["name"] == new_port["name"]:
+                            duplicate = True
+                            break
+                    if not duplicate:
+                        self.sourcePorts["objects"].append(new_port)
+                        logging.info(
+                            f'Adding "{name}" to sourcePorts for this AccessRules.'
+                        )
+                else:
+                    self.sourcePorts = {
+                        "objects": [
+                            {"name": item.name, "id": item.id, "type": item.type}
+                        ]
+                    }
+                    logging.info(
+                        f'Adding "{name}" to sourcePorts for this AccessRules.'
+                    )
+            else:
+                logging.warning(
+                    f'Protocol Port Port Group: "{name}", '
+                    f"not found.  Cannot add to AccessRules."
+                )
         elif action == "remove":
             pport_json = ProtocolPortObjects(fmc=self.fmc)
             pport_json.get(name=name)
@@ -560,6 +592,38 @@ class AccessRules(APIClassTemplate):
             else:
                 item = PortObjectGroups(fmc=self.fmc)
                 item.get(name=name)
+            if "id" in item.__dict__:
+                if "destinationPorts" in self.__dict__:
+                    new_port = {"name": item.name, "id": item.id, "type": item.type}
+                    duplicate = False
+                    if "objects" not in self.destinationPorts:
+                        self.__dict__["destinationPorts"]["objects"] = []
+                    for obj in self.destinationPorts["objects"]:
+                        if obj["name"] == new_port["name"]:
+                            duplicate = True
+                            break
+                    if not duplicate:
+                        self.destinationPorts["objects"].append(new_port)
+                        logging.info(
+                            f'Adding "{name}" to destinationPorts for this AccessRules.'
+                        )
+                else:
+                    self.destinationPorts = {
+                        "objects": [
+                            {"name": item.name, "id": item.id, "type": item.type}
+                        ]
+                    }
+                    logging.info(
+                        f'Adding "{name}" to destinationPorts for this AccessRules.'
+                    )
+            else:
+                logging.warning(
+                    f'Protocol Port or Protocol Port Group: "{name}", '
+                    f"not found.  Cannot add to AccessRules."
+                )
+        if action == "addgroup":
+            item = PortObjectGroups(fmc=self.fmc)
+            item.get(name=name)
             if "id" in item.__dict__:
                 if "destinationPorts" in self.__dict__:
                     new_port = {"name": item.name, "id": item.id, "type": item.type}

--- a/fmcapi/api_objects/policy_services/accessrules.py
+++ b/fmcapi/api_objects/policy_services/accessrules.py
@@ -469,7 +469,7 @@ class AccessRules(APIClassTemplate):
         """
         Add/modify name to sourcePorts field of AccessRules object.
 
-        :param action: (str) 'add', 'remove', or 'clear'
+        :param action: (str) 'add', 'addgroup', 'remove', or 'clear'
         :param name: (str) Name of Port in FMC.
         :return: None
         """
@@ -579,7 +579,7 @@ class AccessRules(APIClassTemplate):
         """
         Add/modify name to destinationPorts field of AccessRules object.
 
-        :param action: (str) 'add', 'remove', or 'clear'
+        :param action: (str) 'add', 'addgroup', 'remove', or 'clear'
         :param name: (str) Name of Port in FMC.
         :return: None
         """


### PR DESCRIPTION
I'm not certain about the logging.debug part, feel free to correct me on that...

- Add an action for "addgroup" to source_port and destination_port
- Move `json.dumps` to logging.debug

This maintains backwards compatibility by not changing the "add" action.