### PR TITLE
Update bridgegroupinterfaces.py MTU range

### DIFF
--- a/fmcapi/api_objects/device_services/bridgegroupinterfaces.py
+++ b/fmcapi/api_objects/device_services/bridgegroupinterfaces.py
@@ -42,7 +42,7 @@ class BridgeGroupInterfaces(APIClassTemplate):
     REQUIRED_FOR_PUT = ["id", "device_id"]
     VALID_FOR_IPV4 = ["static", "dhcp", "pppoe"]
     VALID_FOR_MODE = ["INLINE", "PASSIVE", "TAP", "ERSPAN", "NONE"]
-    VALID_FOR_MTU = range(64, 9000)
+    VALID_FOR_MTU = range(64, 9085)
 
     def __init__(self, fmc, **kwargs):
         """


### PR DESCRIPTION
Data interfaces on FTD can have MTU in range 64 - 9084B.
(always at least 100B less then cluster interface - which can have MTU between 1400 - 9184)

Please change current 9000 to 9084. I am using 9085 because range function is not including highest number.