### PR TITLE
store json object as fmc class attribute when call to fmc api fails with http exception

### DIFF
--- a/fmcapi/fmc.py
+++ b/fmcapi/fmc.py
@@ -261,7 +261,7 @@ class FMC(object):
             logging.error(f"json_response -->\t{json_response}")
             if response:
                 response.close()
-            return None
+            return json_response
         if response:
             response.close()
         try:

--- a/fmcapi/fmc.py
+++ b/fmcapi/fmc.py
@@ -112,6 +112,7 @@ class FMC(object):
         self.platform_url = None
         self.page_counter = None
         self.more_items = []
+        self.error_response = None
 
     def __enter__(self):
         """
@@ -259,9 +260,10 @@ class FMC(object):
         except requests.exceptions.HTTPError as err:
             logging.error(f"Error in POST operation --> {str(err)}")
             logging.error(f"json_response -->\t{json_response}")
+            self.error_response = json_response
             if response:
                 response.close()
-            return json_response
+            return None
         if response:
             response.close()
         try:


### PR DESCRIPTION
Rather than returning None, this will return the API response object when a call to the FMC fails. 
This will other code layered on this package to provide dynamic feedback in failure scenarios 