### PR TITLE
Support for description field in nat rules

### DIFF
--- a/fmcapi/api_objects/policy_services/manualnatrules.py
+++ b/fmcapi/api_objects/policy_services/manualnatrules.py
@@ -40,6 +40,7 @@ class ManualNatRules(APIClassTemplate):
         "patOptions",
         "unidirectional",
         "enabled",
+        "description",
     ]
     VALID_FOR_KWARGS = VALID_JSON_DATA + []
     PREFIX_URL = "/policy/ftdnatpolicies"


### PR DESCRIPTION
You can specify description field for every nat rule. I tested this on fmc 6.7, but the field is there on older versions too.