### PR TITLE
Support for description field in nat rule

### DIFF
--- a/fmcapi/api_objects/policy_services/autonatrules.py
+++ b/fmcapi/api_objects/policy_services/autonatrules.py
@@ -31,6 +31,7 @@ class AutoNatRules(APIClassTemplate):
         "translatedPort",
         "serviceProtocol",
         "patOptions",
+        "description",
     ]
     VALID_FOR_KWARGS = VALID_JSON_DATA + []
     PREFIX_URL = "/policy/ftdnatpolicies"


### PR DESCRIPTION
You can specify description field for every nat rule. I tested this on fmc 6.7, but the field is there on older versions too.